### PR TITLE
BREAKING CHANGE: new API to import this module

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "/lib"
+    "./lib"
   ],
   "homepage": "https://github.com/mdapi-issues/listmetadata-installed-missing-namespaceprefix",
   "keywords": [
@@ -35,7 +35,7 @@
     "MWE"
   ],
   "license": "MIT",
-  "main": "/lib/workaround.js",
+  "main": "./lib/workaround.js",
   "publishConfig": {
     "access": "public"
   },

--- a/src/workaround.ts
+++ b/src/workaround.ts
@@ -2,7 +2,7 @@ import type { FileProperties } from 'jsforce';
 
 const BROKEN_TYPES = ['CustomMetadata', 'Layout', 'QuickAction'];
 
-export default function addMissingNamespace(
+export function addMissingNamespace(
   fileProperties: Array<FileProperties>
 ): Array<FileProperties> {
   return fileProperties.map((fileProperty) => {

--- a/test/issue.e2e-spec.ts
+++ b/test/issue.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Org } from '@salesforce/core';
 import { expect } from 'chai';
-import listBrokenMetadata from './issue';
+import { listBrokenMetadata } from './issue';
 
 describe('issue', function () {
   let fileProperties;

--- a/test/issue.ts
+++ b/test/issue.ts
@@ -1,7 +1,7 @@
 import type { Connection, FileProperties } from 'jsforce';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default async function listBrokenMetadata(
+export async function listBrokenMetadata(
   conn: Connection
 ): Promise<Array<FileProperties>> {
   let fileProperties = await conn.metadata.list([

--- a/test/workaround.test.ts
+++ b/test/workaround.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { promises } from 'fs';
 import * as path from 'path';
-import addMissingNamespace from '../src/workaround';
+import { addMissingNamespace } from '../src/workaround';
 import * as expected from './fixtures/expected.json';
 
 describe('workaround', function () {


### PR DESCRIPTION
This should improve the developer experience as described here:
https://basarat.gitbook.io/typescript/main-1/defaultisbad

- use named export instead of default export
- make the workaround the primary entry point of this module

Please migrate your code as follows:

```diff
- import addMissingNamespace from '@mdapi-issues/listmetadata-installed-missing-namespaceprefix/lib/workaround'
+ import { addMissingNamespace } from '@mdapi-issues/listmetadata-installed-missing-namespaceprefix'
```